### PR TITLE
fix-#31 [계량도구리스트] on off 상태값 변경시 강제종료 버그 수정

### DIFF
--- a/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/tools_list/ToolsFragmentNormal.kt
+++ b/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/tools_list/ToolsFragmentNormal.kt
@@ -72,9 +72,6 @@ class ToolsFragmentNormal : Fragment() {
         // 리사이클러뷰 사이즈 고정 해제
         layout_normalRecyclerView.setHasFixedSize(false)
 
-        changeToggleStatus()
-
-
     }
 
     private fun changeToggleStatus() {
@@ -87,37 +84,23 @@ class ToolsFragmentNormal : Fragment() {
             toggleUnitStatus(ITEM_STATUS_ON, toggleChecked)
         }
 
-        toggleChecked.clear()
-        toggleNotChecked.clear()
-
         realm.commitTransaction()
     }
 
-    private fun toggleUnitStatus(status: Int, toggleList: MutableList<Long>) {
+    private fun toggleUnitStatus(status: Int, toggleList: MutableSet<Long>) {
         for (itemId in toggleList) {
             val toggleStatus = realm.where(MeasureUnit::class.java).equalTo("unitId", itemId).findFirst()!!
             toggleStatus.unitStatus = status
         }
+        toggleList.clear()
     }
 
-
-    private fun insertData() {
-        realm.beginTransaction()
-
-        val newItem = realm.createObject(MeasureUnit::class.java, newId())
-        newItem.unitNameBold = "일반계량"
-        newItem.unitNameSoft = "일반"
-        newItem.unitType = TYPE_NORMAL
-
-        realm.commitTransaction()
-    }
-
-    private fun newId(): Long {
-        val maxId = realm.where(MeasureUnit::class.java).max("unitId")
-        if (maxId != null) {
-            return maxId.toLong() + 1
+    override fun onResume() {
+        super.onResume()
+        if (isToggleClicked) {
+            changeToggleStatus()
+            isToggleClicked = false
         }
-        return 0
     }
 
     override fun onStop() {

--- a/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/tools_list/ToolsRecyclerAdapterLife.kt
+++ b/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/tools_list/ToolsRecyclerAdapterLife.kt
@@ -68,14 +68,18 @@ class ToolsRecyclerAdapterLife(
 
         fun isToggleChecked() {
             toggleOnOff.setOnCheckedChangeListener{ toggleOnOff, _ ->
+                isToggleClicked = true
+
                 val dataId = data!![adapterPosition].unitId
                 if(toggleOnOff.isChecked){
                     toggleChecked.add(dataId)
                 } else {
                     if (dataId in toggleChecked){
                         toggleChecked.remove(dataId)
+                    } else {
+                        toggleNotChecked.add(dataId)
                     }
-                    toggleNotChecked.add(dataId)
+
                 }
 
             }

--- a/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/tools_list/checked.kt
+++ b/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/tools_list/checked.kt
@@ -1,8 +1,10 @@
 package cookcook.nexters.com.amoogye.views.tools.tools_list
 
-var checkedList = mutableListOf<Long>()
+var checkedList = mutableSetOf<Long>()
 
-var toggleChecked = mutableListOf<Long>()
-var toggleNotChecked = mutableListOf<Long>()
+var toggleChecked = mutableSetOf<Long>()
+var toggleNotChecked = mutableSetOf<Long>()
 
 var utilCantDelete = false
+
+var isToggleClicked = false


### PR DESCRIPTION
1. 문제가 생긴 이유
- 이미 삭제된 아이템의 아이디가 onoff 상태값을 저장하는 list에 남아있어서, 이미 제거된 데이터를 realm 에서 가져오려고 했음

로직 : Adapter에서 onoff 상태값의 체크이벤트 확인 -> 상태가 바뀐 아이템의 아이디를 list에 저장 -> 메인 프래그먼트에서 list에 저장된 아이디의 데이터를 realm에서 가져와서 onoff 상태값 변경

---
2. 해결
- 상태값 중복 저장을 막기 위해 list -> set 변경
- 아이템 삭제 시 onoff 상태값을 저장하는 set에 삭제될 아이템의 아이디가 있다면 함께 제거
- 화면이 바뀔 때, 체크이벤트가 발생했을 때만 상태값 변경하는 함수를 호출하도록 변경