### PR TITLE
Feature #46/계량도구 리스트 편집모드 UI 변경

### DIFF
--- a/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/MeasureUnitStatus.kt
+++ b/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/MeasureUnitStatus.kt
@@ -5,3 +5,5 @@ const val TYPE_LIFE = 1
 
 const val ITEM_STATUS_OFF = 0
 const val ITEM_STATUS_ON = 1
+
+const val NUM_DEFAULT_ITEMS = 5

--- a/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/SwipeLockerbleViewPager.kt
+++ b/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/SwipeLockerbleViewPager.kt
@@ -1,4 +1,4 @@
-package cookcook.nexters.com.amoogye.views.tools.add_tools
+package cookcook.nexters.com.amoogye.views.tools
 
 import android.content.Context
 import android.util.AttributeSet

--- a/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/ToolsFragment.kt
+++ b/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/ToolsFragment.kt
@@ -8,11 +8,12 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import cookcook.nexters.com.amoogye.R
 import cookcook.nexters.com.amoogye.views.tools.add_tools.AddUtilActivity
+import cookcook.nexters.com.amoogye.views.tools.tools_list.ToolsFragmentLife
 import cookcook.nexters.com.amoogye.views.tools.tools_list.ToolsViewPageAdapter
 import kotlinx.android.synthetic.main.fragment_tools.*
 
 
-class ToolsFragment : Fragment() {
+class ToolsFragment : Fragment() , ToolsFragmentLife.OnClickEditModeListener {
 
     companion object {
         // 선택 선언 1 (Fragment를 싱글턴으로 사용 시)
@@ -27,6 +28,28 @@ class ToolsFragment : Fragment() {
         }
     }
 
+    override fun onAttachFragment(fragment : Fragment){
+        if(fragment is ToolsFragmentLife) {
+            fragment.setOnClickEditModeListener(this)
+        }
+    }
+
+
+    override fun onInvisibleTabLayout() {
+        layout_tools_tab_layout.visibility = View.INVISIBLE
+    }
+
+    override fun onVisibleTabLayout() {
+        layout_tools_tab_layout.visibility = View.VISIBLE
+    }
+
+    override fun onDisableSwipe() {
+        layout_Tools_viewPager.setSwipePagingEnabled(false)
+    }
+
+    override fun onAbleSwipe() {
+        layout_Tools_viewPager.setSwipePagingEnabled(true)
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         super.onCreateView(inflater, container, savedInstanceState)
@@ -40,7 +63,7 @@ class ToolsFragment : Fragment() {
         layout_Tools_viewPager.adapter = toolsFragmentAdapter
 
         layout_tools_tab_layout.setupWithViewPager(layout_Tools_viewPager)
-
+        layout_Tools_viewPager.setSwipePagingEnabled(true)
 
         layout_tools_dimScreen.setOnClickListener {
             layout_tools_dimScreen.visibility = View.GONE
@@ -53,3 +76,4 @@ class ToolsFragment : Fragment() {
         }
     }
 }
+

--- a/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/flagIsEditMode.kt
+++ b/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/flagIsEditMode.kt
@@ -1,3 +1,0 @@
-package cookcook.nexters.com.amoogye.views.tools
-
-var flagIsEditMode = false

--- a/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/tools_list/ToolsFragmentLife.kt
+++ b/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/tools_list/ToolsFragmentLife.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.tabs.TabLayout
 import cookcook.nexters.com.amoogye.R
 import cookcook.nexters.com.amoogye.views.tools.*
 import io.realm.Realm
@@ -26,6 +27,19 @@ class ToolsFragmentLife : Fragment() {
             }
             return INSTANCE!!
         }
+    }
+
+    internal lateinit var callback: OnClickEditModeListener
+
+    fun setOnClickEditModeListener (callback: OnClickEditModeListener) {
+        this.callback = callback
+    }
+
+    interface OnClickEditModeListener {
+        fun onInvisibleTabLayout()
+        fun onVisibleTabLayout()
+        fun onDisableSwipe()
+        fun onAbleSwipe()
     }
 
     lateinit var realm: Realm
@@ -70,17 +84,21 @@ class ToolsFragmentLife : Fragment() {
                 btn_edit_delete.visibility = View.VISIBLE
                 flagIsEditMode = true
                 recyclerAdapter.notifyDataSetChanged()
+                callback.onInvisibleTabLayout()
+                callback.onDisableSwipe()
+            }
 
-                if (isToggleClicked) {
-                    changeToggleStatus()
-                    isToggleClicked = false
-                }
+            if (isToggleClicked) {
+                changeToggleStatus()
+                isToggleClicked = false
             }
         }
 
         btn_edit_cancel.setOnClickListener {
             exitEditMode()
             recyclerAdapter.notifyDataSetChanged()
+            callback.onVisibleTabLayout()
+            callback.onAbleSwipe()
         }
 
         btn_edit_delete.setOnClickListener {
@@ -103,6 +121,13 @@ class ToolsFragmentLife : Fragment() {
         btn_edit_delete.visibility = View.GONE
         flagIsEditMode = false
     }
+
+    private fun clickEditChangeParent() {
+        val pf = (parentFragment as ToolsFragment).parentFragment
+        val tab = pf!!.view!!.findViewById<TabLayout>(R.id.layout_tools_tab_layout)
+        tab!!.visibility = View.INVISIBLE
+    }
+
 
     private fun areAllItemsDefault(): Boolean {
         realm.beginTransaction()

--- a/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/tools_list/ToolsFragmentLife.kt
+++ b/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/tools_list/ToolsFragmentLife.kt
@@ -97,15 +97,13 @@ class ToolsFragmentLife : Fragment() {
         btn_edit_cancel.setOnClickListener {
             exitEditMode()
             recyclerAdapter.notifyDataSetChanged()
-            callback.onVisibleTabLayout()
-            callback.onAbleSwipe()
         }
 
         btn_edit_delete.setOnClickListener {
-            deleteData()
-            exitEditMode()
-            recyclerAdapter.notifyDataSetChanged()
-
+            if (checkedList.isNotEmpty()){
+                deleteData()
+                recyclerAdapter.notifyDataSetChanged()
+            }
         }
 
         test_btn_insert_data.setOnClickListener {
@@ -120,14 +118,9 @@ class ToolsFragmentLife : Fragment() {
         btn_edit_cancel.visibility = View.GONE
         btn_edit_delete.visibility = View.GONE
         flagIsEditMode = false
+        callback.onVisibleTabLayout()
+        callback.onAbleSwipe()
     }
-
-    private fun clickEditChangeParent() {
-        val pf = (parentFragment as ToolsFragment).parentFragment
-        val tab = pf!!.view!!.findViewById<TabLayout>(R.id.layout_tools_tab_layout)
-        tab!!.visibility = View.INVISIBLE
-    }
-
 
     private fun areAllItemsDefault(): Boolean {
         realm.beginTransaction()
@@ -198,6 +191,8 @@ class ToolsFragmentLife : Fragment() {
         checkedList.clear()
 
         realm.commitTransaction()
+
+        exitEditMode()
     }
 
     override fun onResume() {

--- a/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/tools_list/ToolsFragmentLife.kt
+++ b/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/tools_list/ToolsFragmentLife.kt
@@ -1,6 +1,7 @@
 package cookcook.nexters.com.amoogye.views.tools.tools_list
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -77,13 +78,13 @@ class ToolsFragmentLife : Fragment() {
         btn_edit_toolList.setOnClickListener {
 
             if (areAllItemsDefault()) {
-                Toast.makeText(context!!, "삭제할 수 있는 계량도구가 없습니다", Toast.LENGTH_SHORT).show()
+                Toast.makeText(context!!, "삭제할 수 있는 계량도구가 없습니다", Toast.LENGTH_LONG).show()
             } else {
+                flagIsEditMode = true
+                recyclerAdapter.notifyDataSetChanged()
                 btn_edit_toolList.visibility = View.GONE
                 btn_edit_cancel.visibility = View.VISIBLE
                 btn_edit_delete.visibility = View.VISIBLE
-                flagIsEditMode = true
-                recyclerAdapter.notifyDataSetChanged()
                 callback.onInvisibleTabLayout()
                 callback.onDisableSwipe()
             }
@@ -126,6 +127,7 @@ class ToolsFragmentLife : Fragment() {
         realm.beginTransaction()
 
         val maxId = newId()
+        Log.d("maxmax", ""+maxId+" "+ NUM_DEFAULT_ITEMS)
 
         realm.commitTransaction()
 

--- a/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/tools_list/ToolsRecyclerAdapterLife.kt
+++ b/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/tools_list/ToolsRecyclerAdapterLife.kt
@@ -39,7 +39,7 @@ class ToolsRecyclerAdapterLife(
 
         private fun getVisibility(): Int {
             val dataId = data!![adapterPosition].unitId
-            if (flagIsEditMode && (dataId > NUM_DEFAULT_ITEMS)) {
+            if (flagIsEditMode && (dataId >= NUM_DEFAULT_ITEMS)) {
                 return View.VISIBLE
             }
             return View.GONE

--- a/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/tools_list/ToolsRecyclerAdapterLife.kt
+++ b/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/tools_list/ToolsRecyclerAdapterLife.kt
@@ -11,7 +11,7 @@ import android.widget.ToggleButton
 import androidx.recyclerview.widget.RecyclerView
 import cookcook.nexters.com.amoogye.R
 import cookcook.nexters.com.amoogye.views.tools.MeasureUnit
-import cookcook.nexters.com.amoogye.views.tools.flagIsEditMode
+import cookcook.nexters.com.amoogye.views.tools.NUM_DEFAULT_ITEMS
 import io.realm.RealmRecyclerViewAdapter
 import io.realm.RealmResults
 
@@ -38,7 +38,10 @@ class ToolsRecyclerAdapterLife(
         }
 
         private fun getVisibility(): Int {
-            if (flagIsEditMode) return View.VISIBLE
+            val dataId = data!![adapterPosition].unitId
+            if (flagIsEditMode && (dataId > NUM_DEFAULT_ITEMS)) {
+                return View.VISIBLE
+            }
             return View.GONE
         }
 

--- a/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/tools_list/checked.kt
+++ b/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/tools_list/checked.kt
@@ -5,6 +5,4 @@ var checkedList = mutableSetOf<Long>()
 var toggleChecked = mutableSetOf<Long>()
 var toggleNotChecked = mutableSetOf<Long>()
 
-var utilCantDelete = false
-
 var isToggleClicked = false

--- a/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/tools_list/flagIsEditMode.kt
+++ b/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/tools_list/flagIsEditMode.kt
@@ -1,0 +1,3 @@
+package cookcook.nexters.com.amoogye.views.tools.tools_list
+
+var flagIsEditMode = false

--- a/app/src/main/res/layout/activity_tools_addutil_main.xml
+++ b/app/src/main/res/layout/activity_tools_addutil_main.xml
@@ -75,14 +75,14 @@
         android:paddingStart="@dimen/add_util_start_end"
         android:paddingEnd="@dimen/add_util_start_end">
 
-        <cookcook.nexters.com.amoogye.views.tools.add_tools.SwipeLockableViewPager
+        <cookcook.nexters.com.amoogye.views.tools.SwipeLockableViewPager
             android:id="@+id/view_pager_add_util"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_above="@id/layout_add_util_outer_bottom_btn"
             android:layout_below="@id/indicator_add_util">
 
-        </cookcook.nexters.com.amoogye.views.tools.add_tools.SwipeLockableViewPager>
+        </cookcook.nexters.com.amoogye.views.tools.SwipeLockableViewPager>
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/indicator_add_util"

--- a/app/src/main/res/layout/fragment_tools.xml
+++ b/app/src/main/res/layout/fragment_tools.xml
@@ -59,7 +59,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <androidx.viewpager.widget.ViewPager
+            <cookcook.nexters.com.amoogye.views.tools.SwipeLockableViewPager
                 android:id="@+id/layout_Tools_viewPager"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent" />

--- a/app/src/main/res/layout/fragment_tools_item.xml
+++ b/app/src/main/res/layout/fragment_tools_item.xml
@@ -4,17 +4,6 @@
     android:layout_height="52dp"
     android:background="@drawable/tools_item_border">
 
-    <CheckBox
-        android:id="@+id/checkBox_lifeTool_Item"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentStart="true"
-        android:layout_centerInParent="true"
-        android:layout_marginStart="@dimen/tools_list_start_end"
-        android:background="@drawable/tools_check_box_onoff"
-        android:button="@color/transparent"
-        android:visibility="gone" />
-
     <TextView
         android:id="@+id/txt_measureUnit_bold"
         android:layout_width="wrap_content"
@@ -23,7 +12,6 @@
         android:layout_marginStart="@dimen/add_util_start_end"
         android:layout_marginTop="@dimen/tools_list_item_bold_top"
         android:layout_marginBottom="@dimen/tools_list_item_bold_bottom"
-        android:layout_toEndOf="@id/checkBox_lifeTool_Item"
         android:text=""
         android:textColor="@color/tools_list_text_color"
         android:textSize="@dimen/tools_list_item_bold_text_size" />
@@ -46,10 +34,22 @@
         android:layout_height="24dp"
         android:layout_alignParentEnd="true"
         android:layout_centerInParent="true"
-        android:layout_marginEnd="@dimen/tools_list_start_end"
         android:layout_marginTop="@dimen/tools_list_button_top"
+        android:layout_marginEnd="@dimen/tools_list_start_end"
         android:layout_marginBottom="@dimen/tools_list_button_bottom"
         android:background="@drawable/tools_list_onoff"
         android:textOff=""
         android:textOn="" />
+
+    <CheckBox
+        android:id="@+id/checkBox_lifeTool_Item"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_centerInParent="true"
+        android:layout_marginStart="@dimen/tools_list_start_end"
+        android:layout_marginEnd="@dimen/tools_list_start_end"
+        android:background="@drawable/tools_check_box_onoff"
+        android:button="@color/transparent"
+        android:visibility="gone" />
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_tools_life_recycler.xml
+++ b/app/src/main/res/layout/fragment_tools_life_recycler.xml
@@ -35,12 +35,24 @@
             android:id="@+id/btn_edit_cancel"
             android:layout_width="26dp"
             android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_marginStart="@dimen/tools_list_start_end"
+            android:background="@color/transparent"
+            android:text="@string/tools_list_edit_close"
+            android:textColor="@color/tools_list_text_color"
+            android:textSize="@dimen/tools_list_edit_text_size"
+            android:visibility="gone" />
+
+        <Button
+            android:id="@+id/btn_edit_delete"
+            android:layout_width="26dp"
+            android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
             android:layout_marginEnd="@dimen/tools_list_start_end"
             android:background="@color/transparent"
-            android:text="@string/tools_list_edit_close"
             android:textColor="@color/tools_list_main_color"
             android:textSize="@dimen/tools_list_edit_text_size"
+            android:text="@string/tools_list_edit_delete"
             android:visibility="gone" />
 
     </RelativeLayout>
@@ -64,18 +76,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="테스트_항목추가" />
-
-        <Button
-            android:id="@+id/btn_edit_delete"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
-            android:background="@color/add_util_main_color"
-            android:padding="@dimen/tools_list_delete_button"
-            android:text="@string/tools_list_edit_delete"
-            android:textColor="@color/white"
-            android:textSize="@dimen/add_util_button_text_size"
-            android:visibility="gone" />
 
 
     </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,7 +38,7 @@
     <string name="tools_list_life">생활 계량도구</string>
     <string name="tools_list_edit">편집</string>
     <string name="tools_list_edit_close">닫기</string>
-    <string name="tools_list_edit_delete">삭제하기</string>
+    <string name="tools_list_edit_delete">삭제</string>
 
     <!-- tools add util-->
     <string name="add_util_title">계량도구 추가</string>


### PR DESCRIPTION
- 탭레아이웃 사라짐, 삭제버튼 위로 올림
- 체크박스 오른쪽으로 이동, 삭제불가 아이템은 체크박스 생성 X, 삭제가능 아이템 없으면 토스트알람


![listEdit](https://user-images.githubusercontent.com/46909380/63200285-a3246700-c0bb-11e9-94b1-5733ad2737ba.gif)
