### PR TITLE
fix-#104 [계량도구] 도구 추가 시 글자 깨짐 수정

### DIFF
--- a/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/add_tools/AddUtilActivity.kt
+++ b/app/src/main/java/cookcook/nexters/com/amoogye/views/tools/add_tools/AddUtilActivity.kt
@@ -65,11 +65,10 @@ class AddUtilActivity : AppCompatActivity(), OnEditTextClickListener,
 
     override fun onAddUtilResult() {
         val nameResult = findViewById<TextView>(R.id.txt_3_user_name)
-        val nameResultUnit = findViewById<TextView>(R.id.txt_3_user_name_unit)
         val result = MeasureUnitSaveData.getInstance().unitNameSoft
+
         MeasureUnitSaveData.getInstance().unitNameBold = itemName
-        nameResult.text = itemName
-        nameResultUnit.text = "($result)"
+        nameResult.text = "$itemName ($result)"
     }
 
 

--- a/app/src/main/res/layout/fragment_addutil_3_complete.xml
+++ b/app/src/main/res/layout/fragment_addutil_3_complete.xml
@@ -7,11 +7,6 @@
     android:paddingStart="@dimen/add_util_start_end"
     android:paddingEnd="@dimen/add_util_start_end">
 
-    <RelativeLayout
-        android:id="@+id/layout_outer_top"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentTop="true">
 
         <RelativeLayout
             android:id="@+id/layout_in_top"
@@ -39,22 +34,13 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/nanum_square_r"
-                android:text="내 밥그릇"
+                android:text="내 밥그릇 (150ml)"
                 android:textColor="@color/add_util_main_color"
                 android:textSize="@dimen/add_util_head_comment_text_size" />
 
             <TextView
-                android:id="@+id/txt_3_user_name_unit"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="(150ml)"
                 android:layout_toEndOf="@id/txt_3_user_name"
-                android:textColor="@color/add_util_main_color"
-                android:textSize="@dimen/add_util_head_comment_text_size" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_toEndOf="@id/txt_3_user_name_unit"
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/nanum_square_r"
                 android:text="@string/add_util_complete_comment"
@@ -62,6 +48,4 @@
                 android:textSize="@dimen/add_util_head_comment_text_size" />
         </RelativeLayout>
 
-
-    </RelativeLayout>
 </RelativeLayout>


### PR DESCRIPTION
- 도구이름과 단위를 각각 붙이지 않고 한꺼번에 처리

![fix](https://user-images.githubusercontent.com/46909380/64139769-fed14d00-ce3c-11e9-8330-f270154e0d93.png)
