### PR TITLE
fix-#128 [설정] switch remove ripple animation

### DIFF
--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -72,6 +72,7 @@
                 android:fontFamily="@font/nanum_square_r"
                 android:paddingStart="@dimen/setting_item_start_end"
                 android:paddingEnd="@dimen/setting_item_start_end"
+                android:background="@null"
                 android:thumb="@drawable/setting_on_off_thumb"
                 android:track="@drawable/setting_on_off_selector"  />
 
@@ -155,6 +156,7 @@
                     android:fontFamily="@font/nanum_square_r"
                     android:paddingStart="@dimen/setting_item_start_end"
                     android:paddingEnd="@dimen/setting_item_start_end"
+                    android:background="@null"
                     android:thumb="@drawable/setting_on_off_thumb"
                     android:track="@drawable/setting_on_off_selector"  />
             </RelativeLayout>
@@ -185,6 +187,7 @@
                     android:fontFamily="@font/nanum_square_r"
                     android:paddingStart="@dimen/setting_item_start_end"
                     android:paddingEnd="@dimen/setting_item_start_end"
+                    android:background="@null"
                     android:thumb="@drawable/setting_on_off_thumb"
                     android:track="@drawable/setting_on_off_selector"/>
             </RelativeLayout>


### PR DESCRIPTION
- android:background ="@null"
- 설정 스위치 상태변경할 때 ripple 애니메이션 제거